### PR TITLE
Unit tests and fixes for Double & Float instances of HomTransform4

### DIFF
--- a/easytensor/easytensor.cabal
+++ b/easytensor/easytensor.cabal
@@ -83,7 +83,8 @@ test-suite et-test
         Numeric.DataFrame.Arbitraries
         Numeric.DataFrame.SubSpaceTest
         Numeric.DataFrame.BasicTest
-        Numeric.MatrixTest
+        Numeric.MatrixDoubleTest
+        Numeric.MatrixFloatTest
         Numeric.QuaternionTest
     build-depends:
         base -any,

--- a/easytensor/src/Numeric/Matrix/Mat44d.hs
+++ b/easytensor/src/Numeric/Matrix/Mat44d.hs
@@ -130,10 +130,10 @@ instance HomTransform4 Double where
 
   {-# INLINE rotateEuler #-}
   rotateEuler x y z = mat44d
-    (cy*cz)  (cx*sz+sx*sy*cz) (sx*sz-cx*sy*cz) 0
-    (-cy*sz) (cx*cz-sx*sy*sz) (sx*cz+cx*sy*sz) 0
-    sy       (-sx*cy)         (cx*cy)          0
-    0        0                0                1
+    (cy*cz)          (-cy*sz)         sy       0
+    (cx*sz+sx*sy*cz) (cx*cz-sx*sy*sz) (-sx*cy) 0
+    (sx*sz-cx*sy*cz) (sx*cz+cx*sy*sz) (cx*cy)  0
+    0                0                0        1
     where
       cx = scalar $ cos x
       sx = scalar $ sin x
@@ -149,9 +149,9 @@ instance HomTransform4 Double where
     (zb!1) (zb!2) (zb!3) tz
     0      0      0      1
     where
-      xb = normalized $ up `cross` zb
-      yb = zb `cross` xb
-      zb = normalized $ foc - cam
+      zb = normalized $ cam - foc -- Basis vector for "backward", since +Z is behind the camera
+      xb = normalized $ up `cross` zb -- Basis vector for "right"
+      yb = zb `cross` xb -- Basis vector for "up"
       ncam = -cam
       tx = xb `dot` ncam
       ty = yb `dot` ncam

--- a/easytensor/src/Numeric/Matrix/Mat44f.hs
+++ b/easytensor/src/Numeric/Matrix/Mat44f.hs
@@ -130,10 +130,10 @@ instance HomTransform4 Float where
 
   {-# INLINE rotateEuler #-}
   rotateEuler x y z = mat44f
-    (cy*cz)  (cx*sz+sx*sy*cz) (sx*sz-cx*sy*cz) 0
-    (-cy*sz) (cx*cz-sx*sy*sz) (sx*cz+cx*sy*sz) 0
-    sy       (-sx*cy)         (cx*cy)          0
-    0        0                0                1
+    (cy*cz)          (-cy*sz)         sy       0
+    (cx*sz+sx*sy*cz) (cx*cz-sx*sy*sz) (-sx*cy) 0
+    (sx*sz-cx*sy*cz) (sx*cz+cx*sy*sz) (cx*cy)  0
+    0                0                0        1
     where
       cx = scalar $ cos x
       sx = scalar $ sin x
@@ -149,9 +149,9 @@ instance HomTransform4 Float where
     (zb!1) (zb!2) (zb!3) tz
     0      0      0      1
     where
-      xb = normalized $ up `cross` zb
-      yb = zb `cross` xb
-      zb = normalized $ foc - cam
+      zb = normalized $ cam - foc -- Basis vector for "backward", since +Z is behind the camera
+      xb = normalized $ up `cross` zb -- Basis vector for "right"
+      yb = zb `cross` xb -- Basis vector for "up"
       ncam = -cam
       tx = xb `dot` ncam
       ty = yb `dot` ncam

--- a/easytensor/test/Numeric/MatrixDoubleTest.hs
+++ b/easytensor/test/Numeric/MatrixDoubleTest.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 
-module Numeric.MatrixTest (runTests) where
+module Numeric.MatrixDoubleTest (runTests) where
 
 
 import           Data.Fixed

--- a/easytensor/test/Numeric/MatrixFloatTest.hs
+++ b/easytensor/test/Numeric/MatrixFloatTest.hs
@@ -1,0 +1,210 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Numeric.MatrixFloatTest (runTests) where
+
+
+import           Data.Fixed
+import           Numeric.DataFrame
+import           Numeric.DataFrame.Arbitraries ()
+import           Numeric.Dimensions
+import           Test.QuickCheck
+
+eps :: Scf
+eps = 0.01
+
+dropW :: (SubSpace t '[] '[3] '[3], SubSpace t '[] '[4] '[4]) => Vector t 4 -> Vector t 3
+dropW v | (x,y,z,_) <- unpackV4 v = vec3 x y z
+
+approxEqF3 :: Vector Float 3 -> Vector Float 3 -> Bool
+approxEqF3 a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
+infix 4 `approxEqF3`
+
+approxEqF4 :: Vector Float 4 -> Vector Float 4 -> Bool
+approxEqF4 a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
+infix 4 `approxEqF4`
+
+approxEqF44 :: Matrix Float 4 4 -> Matrix Float 4 4 -> Bool
+approxEqF44 a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
+infix 4 `approxEqF44`
+
+prop_detTranspose :: Matrix '[Float, Float] (XN 2) (XN 2) -> Bool
+prop_detTranspose (XFrame (x :*: y :*: Z))
+  | -- infer KnownDim for both dimensions of matrix x (and y)
+    KnownDims <- dims `inSpaceOf` x
+  = let m = diag (ewfoldl max 0 $ abs x) + x %* transpose y
+        a = det m
+        b = det $ transpose m
+    in abs (a - b) / (abs a + abs b + 1) <= eps
+
+prop_inverse :: Matrix '[Float, Float] (XN 2) (XN 2) -> Bool
+prop_inverse (XFrame (x :*: y :*: Z))
+  | -- infer KnownDim for both dimensions of matrix x (and y)
+    (KnownDims :: Dims ns) <- dims `inSpaceOf` x
+    -- cumbersose inverse instance requires PrimBytes (Vector t n)
+  , E <- inferASing' @Float @'[Head ns]
+  , E <- inferPrim' @Float @'[Head ns]
+  = let m = diag base + x %* transpose y
+        mi = inverse m
+        err a b = ewfoldl max 0 (abs (b - a)) / base
+        base = ewfoldl max 0.5 (abs x) + ewfoldl max 0.5 (abs y)
+    in   err eye (m %* mi) <= eps
+      && err eye (mi %* m) <= eps
+
+prop_LU :: Matrix '[Float, Float] (XN 2) (XN 2) -> Bool
+prop_LU (XFrame (x :*: y :*: Z))
+  | -- infer KnownDim for both dimensions of matrix x (and y)
+    (KnownDims :: Dims ns) <- dims `inSpaceOf` x
+    -- cumbersose inverse instance requires PrimBytes (Vector t n)
+  , E <- inferASing' @Float @'[Head ns]
+  , E <- inferPrim' @Float @'[Head ns]
+  = let m = diag base + x %* transpose y
+        f = lu m
+        err a b = ewfoldl max 0 (abs (b - a)) / base
+        base = ewfoldl max 0.5 (abs x) + ewfoldl max 0.5 (abs y)
+    in err (luPerm f %* m) (luLower f %* luUpper f) <= eps
+
+prop_translate3vs4 :: Vector Float 4 -> Bool
+prop_translate3vs4 v = translate4 v == translate3 (dropW v)
+  
+prop_translate4 :: Vector Float 4 -> Vector Float 3 -> Bool
+prop_translate4 a b = translate4 a %* toHomPoint b == toHomPoint (dropW a + b)
+
+prop_translate3 :: Vector Float 3 -> Vector Float 3 -> Bool
+prop_translate3 a b = translate3 a %* toHomPoint b == toHomPoint (a + b)
+
+prop_rotateX :: Vector Float 4 -> Bool
+prop_rotateX v | (x,y,z,w) <- unpackV4 v =
+  and [
+    rotateX (-2 * pi)   %* v `approxEqF4` v,
+    rotateX (-1.5 * pi) %* v `approxEqF4` vec4 x (-z) y w,
+    rotateX (-pi)       %* v `approxEqF4` vec4 x (-y) (-z) w,
+    rotateX (-0.5 * pi) %* v `approxEqF4` vec4 x z (-y) w,
+    rotateX 0           %* v `approxEqF4` v,
+    rotateX (0.5 * pi)  %* v `approxEqF4` vec4 x (-z) y w,
+    rotateX pi          %* v `approxEqF4` vec4 x (-y) (-z) w,
+    rotateX (1.5 * pi)  %* v `approxEqF4` vec4 x z (-y) w,
+    rotateX (2 * pi)    %* v `approxEqF4` v
+  ]
+
+prop_rotateY :: Vector Float 4 -> Bool
+prop_rotateY v | (x,y,z,w) <- unpackV4 v =
+  and [
+    rotateY (-2 * pi)   %* v `approxEqF4` v,
+    rotateY (-1.5 * pi) %* v `approxEqF4` vec4 z y (-x) w,
+    rotateY (-pi)       %* v `approxEqF4` vec4 (-x) y (-z) w,
+    rotateY (-0.5 * pi) %* v `approxEqF4` vec4 (-z) y x w,
+    rotateY 0           %* v `approxEqF4` v,
+    rotateY (0.5 * pi)  %* v `approxEqF4` vec4 z y (-x) w,
+    rotateY pi          %* v `approxEqF4` vec4 (-x) y (-z) w,
+    rotateY (1.5 * pi)  %* v `approxEqF4` vec4 (-z) y x w,
+    rotateY (2 * pi)    %* v `approxEqF4` v
+  ]
+
+prop_rotateZ :: Vector Float 4 -> Bool
+prop_rotateZ v | (x,y,z,w) <- unpackV4 v =
+  and [
+    rotateZ (-2 * pi)   %* v `approxEqF4` v,
+    rotateZ (-1.5 * pi) %* v `approxEqF4` vec4 (-y) x z w,
+    rotateZ (-pi)       %* v `approxEqF4` vec4 (-x) (-y) z w,
+    rotateZ (-0.5 * pi) %* v `approxEqF4` vec4 y (-x) z w,
+    rotateZ 0           %* v `approxEqF4` v,
+    rotateZ (0.5 * pi)  %* v `approxEqF4` vec4 (-y) x z w,
+    rotateZ pi          %* v `approxEqF4` vec4 (-x) (-y) z w,
+    rotateZ (1.5 * pi)  %* v `approxEqF4` vec4 y (-x) z w,
+    rotateZ (2 * pi)    %* v `approxEqF4` v
+  ]
+
+prop_rotate :: Float -> Bool
+prop_rotate a =
+  and [
+    rotate (vec3 1 0 0) a `approxEqF44` rotateX a,
+    rotate (vec3 0 1 0) a `approxEqF44` rotateY a,
+    rotate (vec3 0 0 1) a `approxEqF44` rotateZ a
+  ]
+
+prop_rotateEuler :: Float -> Float -> Float -> Bool
+prop_rotateEuler x y z = rotateEuler x y z `approxEqF44` rotateX x %* rotateY y %* rotateZ z
+
+prop_lookAt :: Vector Float 3 -> Vector Float 3 -> Vector Float 3 -> Bool
+prop_lookAt up cam foc =
+  and [
+    (normalized . fromHom $ m %* toHomPoint foc) `approxEqF3` vec3 0 0 (-1),
+    fromHom (m %* toHomPoint cam) `approxEqF3` 0,
+    fromHom (m %* toHomVector xb) `approxEqF3` vec3 1 0 0,
+    fromHom (m %* toHomVector yb) `approxEqF3` vec3 0 1 0,
+    fromHom (m %* toHomVector zb) `approxEqF3` vec3 0 0 1
+  ]
+  where
+    m = lookAt up cam foc
+    zb = normalized $ cam - foc
+    xb = normalized $ up `cross` zb
+    yb = zb `cross` xb
+
+prop_perspective :: Float -> Float -> Float -> Float -> Bool
+prop_perspective a b c d =
+  and [
+    projectTo 0 0 n       `approxEqF3` vec3 0 0 (-1),
+    projectTo 0 0 f       `approxEqF3` vec3 0 0 1,
+    projectTo 1 1 n       `approxEqF3` vec3 1 1 (-1),
+    projectTo 1 (-1) n    `approxEqF3` vec3 1 (-1) (-1),
+    projectTo (-1) 1 n    `approxEqF3` vec3 (-1) 1 (-1),
+    projectTo (-1) (-1) n `approxEqF3` vec3 (-1) (-1) (-1),
+    projectTo 1 1 f       `approxEqF3` vec3 1 1 1,
+    projectTo 1 (-1) f    `approxEqF3` vec3 1 (-1) 1,
+    projectTo (-1) 1 f    `approxEqF3` vec3 (-1) 1 1,
+    projectTo (-1) (-1) f `approxEqF3` vec3 (-1) (-1) 1
+  ]
+  where
+    n = 1.0 + mod' a 9.0 -- Near plane in range [1, 10)
+    f = n + 1.0 + mod' b 99.0 -- Far plane in range [n + 1, n + 100)
+    fovy = (0.1 * pi) + mod' c (0.8 * pi) -- Y-axis field of view in range [0.1*pi, 0.9*pi)
+    aspect = 0.25 + mod' d 4.0 -- Aspect ration in range [1/4, 4/1]
+    hpd = tan (fovy * 0.5) -- height/distance
+    wpd = aspect * hpd -- width/distance
+    m = perspective n f fovy aspect
+    projectTo x' y' z = fromHom $ m %* vec4 (x' * wpd * z) (y' * hpd * z) (-z) 1
+
+prop_orthogonal :: Float -> Float -> Float -> Float -> Bool
+prop_orthogonal a b c d =
+  and [
+    projectTo 0 0 n       `approxEqF3` vec3 0 0 (-1),
+    projectTo 0 0 f       `approxEqF3` vec3 0 0 1,
+    projectTo 1 1 n       `approxEqF3` vec3 1 1 (-1),
+    projectTo 1 (-1) n    `approxEqF3` vec3 1 (-1) (-1),
+    projectTo (-1) 1 n    `approxEqF3` vec3 (-1) 1 (-1),
+    projectTo (-1) (-1) n `approxEqF3` vec3 (-1) (-1) (-1),
+    projectTo 1 1 f       `approxEqF3` vec3 1 1 1,
+    projectTo 1 (-1) f    `approxEqF3` vec3 1 (-1) 1,
+    projectTo (-1) 1 f    `approxEqF3` vec3 (-1) 1 1,
+    projectTo (-1) (-1) f `approxEqF3` vec3 (-1) (-1) 1
+  ]
+  where
+    n = 1.0 + mod' a 9.0 -- Near plane in range [1, 10)
+    f = n + 1.0 + mod' b 99.0 -- Far plane in range [n + 1, n + 100)
+    w = 1.0 + mod' c 9999.0 -- Width in range [1, 10000)
+    h = 1.0 + mod' d 9999.0 -- Height in range [1, 10000)
+    m = orthogonal n f w h
+    projectTo x' y' z = fromHom $ m %* vec4 (x' * w * 0.5) (y' * h * 0.5) (-z) 1
+
+prop_toHomPoint :: Vector Float 3 -> Bool
+prop_toHomPoint v | (x,y,z) <- unpackV3 v = toHomPoint v == vec4 x y z 1
+
+prop_toHomVector :: Vector Float 3 -> Bool
+prop_toHomVector v | (x,y,z) <- unpackV3 v = toHomVector v == vec4 x y z 0
+
+prop_fromHom :: Vector Float 4 -> Bool
+prop_fromHom v | (x,y,z,w) <- unpackV4 v =
+  case w of
+    0 -> fromHom v == vec3 x y z
+    _ -> fromHom v `approxEqF3` vec3 (x/w) (y/w) (z/w)
+
+return []
+runTests :: IO Bool
+runTests = $quickCheckAll

--- a/easytensor/test/Numeric/MatrixFloatTest.hs
+++ b/easytensor/test/Numeric/MatrixFloatTest.hs
@@ -13,7 +13,9 @@ module Numeric.MatrixFloatTest (runTests) where
 import           Data.Fixed
 import           Numeric.DataFrame
 import           Numeric.DataFrame.Arbitraries ()
+import           Numeric.DataFrame.Internal.Array.Class
 import           Numeric.Dimensions
+import           Numeric.PrimBytes
 import           Test.QuickCheck
 
 eps :: Scf
@@ -22,17 +24,17 @@ eps = 0.01
 dropW :: (SubSpace t '[] '[3] '[3], SubSpace t '[] '[4] '[4]) => Vector t 4 -> Vector t 3
 dropW v | (x,y,z,_) <- unpackV4 v = vec3 x y z
 
-approxEqF3 :: Vector Float 3 -> Vector Float 3 -> Bool
-approxEqF3 a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
-infix 4 `approxEqF3`
-
-approxEqF4 :: Vector Float 4 -> Vector Float 4 -> Bool
-approxEqF4 a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
-infix 4 `approxEqF4`
-
-approxEqF44 :: Matrix Float 4 4 -> Matrix Float 4 4 -> Bool
-approxEqF44 a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
-infix 4 `approxEqF44`
+approxEq ::
+  forall (ds :: [Nat]).
+  (
+    Dimensions ds,
+    Num (DataFrame Float ds),
+    PrimBytes (DataFrame Float ds),
+    PrimArray Float (DataFrame Float ds)
+  ) =>
+  DataFrame Float ds -> DataFrame Float ds -> Bool
+approxEq a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
+infix 4 `approxEq`
 
 prop_detTranspose :: Matrix '[Float, Float] (XN 2) (XN 2) -> Bool
 prop_detTranspose (XFrame (x :*: y :*: Z))
@@ -82,64 +84,64 @@ prop_translate3 a b = translate3 a %* toHomPoint b == toHomPoint (a + b)
 prop_rotateX :: Vector Float 4 -> Bool
 prop_rotateX v | (x,y,z,w) <- unpackV4 v =
   and [
-    rotateX (-2 * pi)   %* v `approxEqF4` v,
-    rotateX (-1.5 * pi) %* v `approxEqF4` vec4 x (-z) y w,
-    rotateX (-pi)       %* v `approxEqF4` vec4 x (-y) (-z) w,
-    rotateX (-0.5 * pi) %* v `approxEqF4` vec4 x z (-y) w,
-    rotateX 0           %* v `approxEqF4` v,
-    rotateX (0.5 * pi)  %* v `approxEqF4` vec4 x (-z) y w,
-    rotateX pi          %* v `approxEqF4` vec4 x (-y) (-z) w,
-    rotateX (1.5 * pi)  %* v `approxEqF4` vec4 x z (-y) w,
-    rotateX (2 * pi)    %* v `approxEqF4` v
+    rotateX (-2 * pi)   %* v `approxEq` v,
+    rotateX (-1.5 * pi) %* v `approxEq` vec4 x (-z) y w,
+    rotateX (-pi)       %* v `approxEq` vec4 x (-y) (-z) w,
+    rotateX (-0.5 * pi) %* v `approxEq` vec4 x z (-y) w,
+    rotateX 0           %* v `approxEq` v,
+    rotateX (0.5 * pi)  %* v `approxEq` vec4 x (-z) y w,
+    rotateX pi          %* v `approxEq` vec4 x (-y) (-z) w,
+    rotateX (1.5 * pi)  %* v `approxEq` vec4 x z (-y) w,
+    rotateX (2 * pi)    %* v `approxEq` v
   ]
 
 prop_rotateY :: Vector Float 4 -> Bool
 prop_rotateY v | (x,y,z,w) <- unpackV4 v =
   and [
-    rotateY (-2 * pi)   %* v `approxEqF4` v,
-    rotateY (-1.5 * pi) %* v `approxEqF4` vec4 z y (-x) w,
-    rotateY (-pi)       %* v `approxEqF4` vec4 (-x) y (-z) w,
-    rotateY (-0.5 * pi) %* v `approxEqF4` vec4 (-z) y x w,
-    rotateY 0           %* v `approxEqF4` v,
-    rotateY (0.5 * pi)  %* v `approxEqF4` vec4 z y (-x) w,
-    rotateY pi          %* v `approxEqF4` vec4 (-x) y (-z) w,
-    rotateY (1.5 * pi)  %* v `approxEqF4` vec4 (-z) y x w,
-    rotateY (2 * pi)    %* v `approxEqF4` v
+    rotateY (-2 * pi)   %* v `approxEq` v,
+    rotateY (-1.5 * pi) %* v `approxEq` vec4 z y (-x) w,
+    rotateY (-pi)       %* v `approxEq` vec4 (-x) y (-z) w,
+    rotateY (-0.5 * pi) %* v `approxEq` vec4 (-z) y x w,
+    rotateY 0           %* v `approxEq` v,
+    rotateY (0.5 * pi)  %* v `approxEq` vec4 z y (-x) w,
+    rotateY pi          %* v `approxEq` vec4 (-x) y (-z) w,
+    rotateY (1.5 * pi)  %* v `approxEq` vec4 (-z) y x w,
+    rotateY (2 * pi)    %* v `approxEq` v
   ]
 
 prop_rotateZ :: Vector Float 4 -> Bool
 prop_rotateZ v | (x,y,z,w) <- unpackV4 v =
   and [
-    rotateZ (-2 * pi)   %* v `approxEqF4` v,
-    rotateZ (-1.5 * pi) %* v `approxEqF4` vec4 (-y) x z w,
-    rotateZ (-pi)       %* v `approxEqF4` vec4 (-x) (-y) z w,
-    rotateZ (-0.5 * pi) %* v `approxEqF4` vec4 y (-x) z w,
-    rotateZ 0           %* v `approxEqF4` v,
-    rotateZ (0.5 * pi)  %* v `approxEqF4` vec4 (-y) x z w,
-    rotateZ pi          %* v `approxEqF4` vec4 (-x) (-y) z w,
-    rotateZ (1.5 * pi)  %* v `approxEqF4` vec4 y (-x) z w,
-    rotateZ (2 * pi)    %* v `approxEqF4` v
+    rotateZ (-2 * pi)   %* v `approxEq` v,
+    rotateZ (-1.5 * pi) %* v `approxEq` vec4 (-y) x z w,
+    rotateZ (-pi)       %* v `approxEq` vec4 (-x) (-y) z w,
+    rotateZ (-0.5 * pi) %* v `approxEq` vec4 y (-x) z w,
+    rotateZ 0           %* v `approxEq` v,
+    rotateZ (0.5 * pi)  %* v `approxEq` vec4 (-y) x z w,
+    rotateZ pi          %* v `approxEq` vec4 (-x) (-y) z w,
+    rotateZ (1.5 * pi)  %* v `approxEq` vec4 y (-x) z w,
+    rotateZ (2 * pi)    %* v `approxEq` v
   ]
 
 prop_rotate :: Float -> Bool
 prop_rotate a =
   and [
-    rotate (vec3 1 0 0) a `approxEqF44` rotateX a,
-    rotate (vec3 0 1 0) a `approxEqF44` rotateY a,
-    rotate (vec3 0 0 1) a `approxEqF44` rotateZ a
+    rotate (vec3 1 0 0) a `approxEq` rotateX a,
+    rotate (vec3 0 1 0) a `approxEq` rotateY a,
+    rotate (vec3 0 0 1) a `approxEq` rotateZ a
   ]
 
 prop_rotateEuler :: Float -> Float -> Float -> Bool
-prop_rotateEuler x y z = rotateEuler x y z `approxEqF44` rotateX x %* rotateY y %* rotateZ z
+prop_rotateEuler pitch yaw roll = rotateEuler pitch yaw roll `approxEq` rotateX pitch %* rotateY yaw %* rotateZ roll
 
 prop_lookAt :: Vector Float 3 -> Vector Float 3 -> Vector Float 3 -> Bool
 prop_lookAt up cam foc =
   and [
-    (normalized . fromHom $ m %* toHomPoint foc) `approxEqF3` vec3 0 0 (-1),
-    fromHom (m %* toHomPoint cam) `approxEqF3` 0,
-    fromHom (m %* toHomVector xb) `approxEqF3` vec3 1 0 0,
-    fromHom (m %* toHomVector yb) `approxEqF3` vec3 0 1 0,
-    fromHom (m %* toHomVector zb) `approxEqF3` vec3 0 0 1
+    (normalized . fromHom $ m %* toHomPoint foc) `approxEq` vec3 0 0 (-1),
+    fromHom (m %* toHomPoint cam) `approxEq` 0,
+    fromHom (m %* toHomVector xb) `approxEq` vec3 1 0 0,
+    fromHom (m %* toHomVector yb) `approxEq` vec3 0 1 0,
+    fromHom (m %* toHomVector zb) `approxEq` vec3 0 0 1
   ]
   where
     m = lookAt up cam foc
@@ -150,16 +152,16 @@ prop_lookAt up cam foc =
 prop_perspective :: Float -> Float -> Float -> Float -> Bool
 prop_perspective a b c d =
   and [
-    projectTo 0 0 n       `approxEqF3` vec3 0 0 (-1),
-    projectTo 0 0 f       `approxEqF3` vec3 0 0 1,
-    projectTo 1 1 n       `approxEqF3` vec3 1 1 (-1),
-    projectTo 1 (-1) n    `approxEqF3` vec3 1 (-1) (-1),
-    projectTo (-1) 1 n    `approxEqF3` vec3 (-1) 1 (-1),
-    projectTo (-1) (-1) n `approxEqF3` vec3 (-1) (-1) (-1),
-    projectTo 1 1 f       `approxEqF3` vec3 1 1 1,
-    projectTo 1 (-1) f    `approxEqF3` vec3 1 (-1) 1,
-    projectTo (-1) 1 f    `approxEqF3` vec3 (-1) 1 1,
-    projectTo (-1) (-1) f `approxEqF3` vec3 (-1) (-1) 1
+    projectTo 0 0 n       `approxEq` vec3 0 0 (-1),
+    projectTo 0 0 f       `approxEq` vec3 0 0 1,
+    projectTo 1 1 n       `approxEq` vec3 1 1 (-1),
+    projectTo 1 (-1) n    `approxEq` vec3 1 (-1) (-1),
+    projectTo (-1) 1 n    `approxEq` vec3 (-1) 1 (-1),
+    projectTo (-1) (-1) n `approxEq` vec3 (-1) (-1) (-1),
+    projectTo 1 1 f       `approxEq` vec3 1 1 1,
+    projectTo 1 (-1) f    `approxEq` vec3 1 (-1) 1,
+    projectTo (-1) 1 f    `approxEq` vec3 (-1) 1 1,
+    projectTo (-1) (-1) f `approxEq` vec3 (-1) (-1) 1
   ]
   where
     n = 1.0 + mod' a 9.0 -- Near plane in range [1, 10)
@@ -174,16 +176,16 @@ prop_perspective a b c d =
 prop_orthogonal :: Float -> Float -> Float -> Float -> Bool
 prop_orthogonal a b c d =
   and [
-    projectTo 0 0 n       `approxEqF3` vec3 0 0 (-1),
-    projectTo 0 0 f       `approxEqF3` vec3 0 0 1,
-    projectTo 1 1 n       `approxEqF3` vec3 1 1 (-1),
-    projectTo 1 (-1) n    `approxEqF3` vec3 1 (-1) (-1),
-    projectTo (-1) 1 n    `approxEqF3` vec3 (-1) 1 (-1),
-    projectTo (-1) (-1) n `approxEqF3` vec3 (-1) (-1) (-1),
-    projectTo 1 1 f       `approxEqF3` vec3 1 1 1,
-    projectTo 1 (-1) f    `approxEqF3` vec3 1 (-1) 1,
-    projectTo (-1) 1 f    `approxEqF3` vec3 (-1) 1 1,
-    projectTo (-1) (-1) f `approxEqF3` vec3 (-1) (-1) 1
+    projectTo 0 0 n       `approxEq` vec3 0 0 (-1),
+    projectTo 0 0 f       `approxEq` vec3 0 0 1,
+    projectTo 1 1 n       `approxEq` vec3 1 1 (-1),
+    projectTo 1 (-1) n    `approxEq` vec3 1 (-1) (-1),
+    projectTo (-1) 1 n    `approxEq` vec3 (-1) 1 (-1),
+    projectTo (-1) (-1) n `approxEq` vec3 (-1) (-1) (-1),
+    projectTo 1 1 f       `approxEq` vec3 1 1 1,
+    projectTo 1 (-1) f    `approxEq` vec3 1 (-1) 1,
+    projectTo (-1) 1 f    `approxEq` vec3 (-1) 1 1,
+    projectTo (-1) (-1) f `approxEq` vec3 (-1) (-1) 1
   ]
   where
     n = 1.0 + mod' a 9.0 -- Near plane in range [1, 10)
@@ -203,7 +205,7 @@ prop_fromHom :: Vector Float 4 -> Bool
 prop_fromHom v | (x,y,z,w) <- unpackV4 v =
   case w of
     0 -> fromHom v == vec3 x y z
-    _ -> fromHom v `approxEqF3` vec3 (x/w) (y/w) (z/w)
+    _ -> fromHom v `approxEq` vec3 (x/w) (y/w) (z/w)
 
 return []
 runTests :: IO Bool

--- a/easytensor/test/Numeric/MatrixTest.hs
+++ b/easytensor/test/Numeric/MatrixTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -9,6 +10,7 @@
 module Numeric.MatrixTest (runTests) where
 
 
+import           Data.Fixed
 import           Numeric.DataFrame
 import           Numeric.DataFrame.Arbitraries ()
 import           Numeric.Dimensions
@@ -16,6 +18,21 @@ import           Test.QuickCheck
 
 eps :: Scd
 eps = 0.0000001
+
+dropW :: (SubSpace t '[] '[3] '[3], SubSpace t '[] '[4] '[4]) => Vector t 4 -> Vector t 3
+dropW v | (x,y,z,_) <- unpackV4 v = vec3 x y z
+
+approxEqD3 :: Vector Double 3 -> Vector Double 3 -> Bool
+approxEqD3 a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
+infix 4 `approxEqD3`
+
+approxEqD4 :: Vector Double 4 -> Vector Double 4 -> Bool
+approxEqD4 a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
+infix 4 `approxEqD4`
+
+approxEqD44 :: Matrix Double 4 4 -> Matrix Double 4 4 -> Bool
+approxEqD44 a b = (eps >=) . ewfoldl @_ @'[] max 0 . abs $ a - b
+infix 4 `approxEqD44`
 
 prop_detTranspose :: Matrix '[Double, Double] (XN 2) (XN 2) -> Bool
 prop_detTranspose (XFrame (x :*: y :*: Z))
@@ -53,6 +70,140 @@ prop_LU (XFrame (x :*: y :*: Z))
         base = ewfoldl max 0.5 (abs x) + ewfoldl max 0.5 (abs y)
     in err (luPerm f %* m) (luLower f %* luUpper f) <= eps
 
+prop_translate3vs4 :: Vector Double 4 -> Bool
+prop_translate3vs4 v = translate4 v == translate3 (dropW v)
+  
+prop_translate4 :: Vector Double 4 -> Vector Double 3 -> Bool
+prop_translate4 a b = translate4 a %* toHomPoint b == toHomPoint (dropW a + b)
+
+prop_translate3 :: Vector Double 3 -> Vector Double 3 -> Bool
+prop_translate3 a b = translate3 a %* toHomPoint b == toHomPoint (a + b)
+
+prop_rotateX :: Vector Double 4 -> Bool
+prop_rotateX v | (x,y,z,w) <- unpackV4 v =
+  and [
+    rotateX (-2 * pi)   %* v `approxEqD4` v,
+    rotateX (-1.5 * pi) %* v `approxEqD4` vec4 x (-z) y w,
+    rotateX (-pi)       %* v `approxEqD4` vec4 x (-y) (-z) w,
+    rotateX (-0.5 * pi) %* v `approxEqD4` vec4 x z (-y) w,
+    rotateX 0           %* v `approxEqD4` v,
+    rotateX (0.5 * pi)  %* v `approxEqD4` vec4 x (-z) y w,
+    rotateX pi          %* v `approxEqD4` vec4 x (-y) (-z) w,
+    rotateX (1.5 * pi)  %* v `approxEqD4` vec4 x z (-y) w,
+    rotateX (2 * pi)    %* v `approxEqD4` v
+  ]
+
+prop_rotateY :: Vector Double 4 -> Bool
+prop_rotateY v | (x,y,z,w) <- unpackV4 v =
+  and [
+    rotateY (-2 * pi)   %* v `approxEqD4` v,
+    rotateY (-1.5 * pi) %* v `approxEqD4` vec4 z y (-x) w,
+    rotateY (-pi)       %* v `approxEqD4` vec4 (-x) y (-z) w,
+    rotateY (-0.5 * pi) %* v `approxEqD4` vec4 (-z) y x w,
+    rotateY 0           %* v `approxEqD4` v,
+    rotateY (0.5 * pi)  %* v `approxEqD4` vec4 z y (-x) w,
+    rotateY pi          %* v `approxEqD4` vec4 (-x) y (-z) w,
+    rotateY (1.5 * pi)  %* v `approxEqD4` vec4 (-z) y x w,
+    rotateY (2 * pi)    %* v `approxEqD4` v
+  ]
+
+prop_rotateZ :: Vector Double 4 -> Bool
+prop_rotateZ v | (x,y,z,w) <- unpackV4 v =
+  and [
+    rotateZ (-2 * pi)   %* v `approxEqD4` v,
+    rotateZ (-1.5 * pi) %* v `approxEqD4` vec4 (-y) x z w,
+    rotateZ (-pi)       %* v `approxEqD4` vec4 (-x) (-y) z w,
+    rotateZ (-0.5 * pi) %* v `approxEqD4` vec4 y (-x) z w,
+    rotateZ 0           %* v `approxEqD4` v,
+    rotateZ (0.5 * pi)  %* v `approxEqD4` vec4 (-y) x z w,
+    rotateZ pi          %* v `approxEqD4` vec4 (-x) (-y) z w,
+    rotateZ (1.5 * pi)  %* v `approxEqD4` vec4 y (-x) z w,
+    rotateZ (2 * pi)    %* v `approxEqD4` v
+  ]
+
+prop_rotate :: Double -> Bool
+prop_rotate a =
+  and [
+    rotate (vec3 1 0 0) a `approxEqD44` rotateX a,
+    rotate (vec3 0 1 0) a `approxEqD44` rotateY a,
+    rotate (vec3 0 0 1) a `approxEqD44` rotateZ a
+  ]
+
+prop_rotateEuler :: Double -> Double -> Double -> Bool
+prop_rotateEuler x y z = rotateEuler x y z `approxEqD44` rotateX x %* rotateY y %* rotateZ z
+
+prop_lookAt :: Vector Double 3 -> Vector Double 3 -> Vector Double 3 -> Bool
+prop_lookAt up cam foc =
+  and [
+    (normalized . fromHom $ m %* toHomPoint foc) `approxEqD3` vec3 0 0 (-1),
+    fromHom (m %* toHomPoint cam) `approxEqD3` 0,
+    fromHom (m %* toHomVector xb) `approxEqD3` vec3 1 0 0,
+    fromHom (m %* toHomVector yb) `approxEqD3` vec3 0 1 0,
+    fromHom (m %* toHomVector zb) `approxEqD3` vec3 0 0 1
+  ]
+  where
+    m = lookAt up cam foc
+    zb = normalized $ cam - foc
+    xb = normalized $ up `cross` zb
+    yb = zb `cross` xb
+
+prop_perspective :: Double -> Double -> Double -> Double -> Bool
+prop_perspective a b c d =
+  and [
+    projectTo 0 0 n       `approxEqD3` vec3 0 0 (-1),
+    projectTo 0 0 f       `approxEqD3` vec3 0 0 1,
+    projectTo 1 1 n       `approxEqD3` vec3 1 1 (-1),
+    projectTo 1 (-1) n    `approxEqD3` vec3 1 (-1) (-1),
+    projectTo (-1) 1 n    `approxEqD3` vec3 (-1) 1 (-1),
+    projectTo (-1) (-1) n `approxEqD3` vec3 (-1) (-1) (-1),
+    projectTo 1 1 f       `approxEqD3` vec3 1 1 1,
+    projectTo 1 (-1) f    `approxEqD3` vec3 1 (-1) 1,
+    projectTo (-1) 1 f    `approxEqD3` vec3 (-1) 1 1,
+    projectTo (-1) (-1) f `approxEqD3` vec3 (-1) (-1) 1
+  ]
+  where
+    n = 1.0 + mod' a 9.0 -- Near plane in range [1, 10)
+    f = n + 1.0 + mod' b 99.0 -- Far plane in range [n + 1, n + 100)
+    fovy = (0.1 * pi) + mod' c (0.8 * pi) -- Y-axis field of view in range [0.1*pi, 0.9*pi)
+    aspect = 0.25 + mod' d 4.0 -- Aspect ration in range [1/4, 4/1]
+    hpd = tan (fovy * 0.5) -- height/distance
+    wpd = aspect * hpd -- width/distance
+    m = perspective n f fovy aspect
+    projectTo x' y' z = fromHom $ m %* vec4 (x' * wpd * z) (y' * hpd * z) (-z) 1
+
+prop_orthogonal :: Double -> Double -> Double -> Double -> Bool
+prop_orthogonal a b c d =
+  and [
+    projectTo 0 0 n       `approxEqD3` vec3 0 0 (-1),
+    projectTo 0 0 f       `approxEqD3` vec3 0 0 1,
+    projectTo 1 1 n       `approxEqD3` vec3 1 1 (-1),
+    projectTo 1 (-1) n    `approxEqD3` vec3 1 (-1) (-1),
+    projectTo (-1) 1 n    `approxEqD3` vec3 (-1) 1 (-1),
+    projectTo (-1) (-1) n `approxEqD3` vec3 (-1) (-1) (-1),
+    projectTo 1 1 f       `approxEqD3` vec3 1 1 1,
+    projectTo 1 (-1) f    `approxEqD3` vec3 1 (-1) 1,
+    projectTo (-1) 1 f    `approxEqD3` vec3 (-1) 1 1,
+    projectTo (-1) (-1) f `approxEqD3` vec3 (-1) (-1) 1
+  ]
+  where
+    n = 1.0 + mod' a 9.0 -- Near plane in range [1, 10)
+    f = n + 1.0 + mod' b 99.0 -- Far plane in range [n + 1, n + 100)
+    w = 1.0 + mod' c 9999.0 -- Width in range [1, 10000)
+    h = 1.0 + mod' d 9999.0 -- Height in range [1, 10000)
+    m = orthogonal n f w h
+    projectTo x' y' z = fromHom $ m %* vec4 (x' * w * 0.5) (y' * h * 0.5) (-z) 1
+
+prop_toHomPoint :: Vector Double 3 -> Bool
+prop_toHomPoint v | (x,y,z) <- unpackV3 v = toHomPoint v == vec4 x y z 1
+
+prop_toHomVector :: Vector Double 3 -> Bool
+prop_toHomVector v | (x,y,z) <- unpackV3 v = toHomVector v == vec4 x y z 0
+
+prop_fromHom :: Vector Double 4 -> Bool
+prop_fromHom v | (x,y,z,w) <- unpackV4 v =
+  case w of
+    0 -> fromHom v == vec3 x y z
+    _ -> fromHom v `approxEqD3` vec3 (x/w) (y/w) (z/w)
 
 return []
 runTests :: IO Bool

--- a/easytensor/test/Spec.hs
+++ b/easytensor/test/Spec.hs
@@ -5,7 +5,8 @@ import           System.Exit
 
 import qualified Numeric.DataFrame.BasicTest
 import qualified Numeric.DataFrame.SubSpaceTest
-import qualified Numeric.MatrixTest
+import qualified Numeric.MatrixDoubleTest
+import qualified Numeric.MatrixFloatTest
 import qualified Numeric.QuaternionTest
 
 
@@ -14,7 +15,8 @@ tests :: IO [Test]
 tests = return
   [ test "DataFrame.Basic"    Numeric.DataFrame.BasicTest.runTests
   , test "DataFrame.SubSpace" Numeric.DataFrame.SubSpaceTest.runTests
-  , test "Matrix"             Numeric.MatrixTest.runTests
+  , test "MatrixDouble"       Numeric.MatrixDoubleTest.runTests
+  , test "MatrixFloat"       Numeric.MatrixFloatTest.runTests
   , test "Quaternion"         Numeric.QuaternionTest.runTests
   ]
 

--- a/easytensor/test/Spec.hs
+++ b/easytensor/test/Spec.hs
@@ -16,7 +16,7 @@ tests = return
   [ test "DataFrame.Basic"    Numeric.DataFrame.BasicTest.runTests
   , test "DataFrame.SubSpace" Numeric.DataFrame.SubSpaceTest.runTests
   , test "MatrixDouble"       Numeric.MatrixDoubleTest.runTests
-  , test "MatrixFloat"       Numeric.MatrixFloatTest.runTests
+  , test "MatrixFloat"        Numeric.MatrixFloatTest.runTests
   , test "Quaternion"         Numeric.QuaternionTest.runTests
   ]
 


### PR DESCRIPTION
I've split MatrixTest into Double and Float variants, and implemented unit tests for the Double and Float instances of HomTransform4.  I also made some fixes to the instances themselves, after encountering some problems while building the unit tests.

1) I had made a mistake in the calculation of the projection matrix's z-basis; hadn't accounted for the "forward" direction being -Z, not +Z.
1) The rotateEuler matrix needed to be transposed in order to satisfy the test property:
   ```hs
   prop_rotateEuler x y z = rotateEuler x y z `approxEqD44` rotateX x %* rotateY y %* rotateZ z
   ```

Please review the test properties to ensure they meet your expectations.  If they don't, we'll need to fix both the test *and* the implementation, because all the tests currently pass.