### PR TITLE
Fixed PrimBytes for GHC 8.10

### DIFF
--- a/easytensor/src/Numeric/PrimBytes.hs
+++ b/easytensor/src/Numeric/PrimBytes.hs
@@ -308,7 +308,7 @@ bFieldOffsetOf :: forall (name :: Symbol) (a :: Type) (b :: Type)
                 . ( PrimBytes a, Elem name (PrimFields a)
                   , KnownSymbol name, Num b)
                => a -> b
-bFieldOffsetOf a = fromIntegral (I# (byteFieldOffset (proxy# @Symbol @name) a))
+bFieldOffsetOf a = fromIntegral (I# (byteFieldOffset (proxy# @name) a))
 
 -- | Same as `Foreign.Storable.peekElemOff`: peek an element @a@ by the offset
 --   measured in @byteSize a@.
@@ -498,7 +498,7 @@ instance GPrimBytes f => GPrimBytes (M1 i c f) where
     gwriteAddr p = coerce (gwriteAddr @f p)
     gbyteSize p = coerce (gbyteSize @f p)
     gbyteAlign p = coerce (gbyteAlign @f p)
-    gbyteFieldOffset p = coerce (gbyteFieldOffset @f p)
+    gbyteFieldOffset p t ps n = coerce (gbyteFieldOffset @f p t ps n)
 
 instance (GPrimBytes f, GPrimBytes g) => GPrimBytes (f :*: g) where
     gfromBytes p t ps i ba = x :*: y


### PR DESCRIPTION
This fixes the following:
```
src/Numeric/PrimBytes.hs:311:55: error:
    • Cannot apply expression of type ‘Proxy# Symbol’
      to a visible type argument ‘name’
    • In the first argument of ‘byteFieldOffset’, namely
        ‘(proxy# @Symbol @name)’
      In the first argument of ‘I#’, namely
        ‘(byteFieldOffset (proxy# @Symbol @name) a)’
      In the first argument of ‘fromIntegral’, namely
        ‘(I# (byteFieldOffset (proxy# @Symbol @name) a))’
    |
311 | bFieldOffsetOf a = fromIntegral (I# (byteFieldOffset (proxy# @Symbol @name) a))
    |                                                       ^^^^^^^^^^^^^^^^^^^^

src/Numeric/PrimBytes.hs:501:34: error:
    • Could not deduce (KnownSymbol name0)
        arising from a use of ‘gbyteFieldOffset’
      from the context: GPrimBytes f
        bound by the instance declaration
        at src/Numeric/PrimBytes.hs:493:10-46
      or from: KnownSymbol name
        bound by the type signature for:
                   gbyteFieldOffset :: forall (name :: Symbol) (p :: k).
                                       KnownSymbol name =>
                                       Proxy# p
                                       -> Word# -> Int# -> Proxy# name -> M1 i c f p -> Int#
        at src/Numeric/PrimBytes.hs:501:5-20
      The type variable ‘name0’ is ambiguous
    • In the first argument of ‘coerce’, namely
        ‘(gbyteFieldOffset @f p)’
      In the expression: coerce (gbyteFieldOffset @f p)
      In an equation for ‘gbyteFieldOffset’:
          gbyteFieldOffset p = coerce (gbyteFieldOffset @f p)
    |
501 |     gbyteFieldOffset p = coerce (gbyteFieldOffset @f p)
    |                                  ^^^^^^^^^^^^^^^^^^^^^
```

I have no idea how `(proxy# @Symbol @name)` ever worked, `proxy#` seems to have only one type argument even in older versions.